### PR TITLE
Some changes to confirm exclusion protocol draft

### DIFF
--- a/src/Diggin/RobotRules/Accepter/TxtAccepter.php
+++ b/src/Diggin/RobotRules/Accepter/TxtAccepter.php
@@ -43,9 +43,9 @@ class TxtAccepter
             }
 
             //record has some user-agents
-            foreach ($useragents as &$u) $u = $u->getValue(); unset($u);
+            foreach ($useragents as &$u) $u = strtolower($u->getValue()); unset($u);
 
-            if (in_array($this->getUserAgent(), $useragents)) {
+            if (in_array(strtolower($this->getUserAgent()), $useragents)) {
                 $ua = $this->getUserAgent();
             } else if (in_array('*', $useragents)) {
                 if (isset($ua)) continue;

--- a/src/Diggin/RobotRules/Accepter/TxtAccepter.php
+++ b/src/Diggin/RobotRules/Accepter/TxtAccepter.php
@@ -109,7 +109,7 @@ class TxtAccepter
             // $ designates the end of the URL
             $value_tmp = preg_replace('#^([^$]+\$?).*$#','$1',$value);
 
-            if (preg_match('#^'. str_replace(array('\*','\$'), array('.*','$'), preg_quote($value_tmp)) . '#', $path)) {
+            if (preg_match('#^'. str_replace(array('\*','\$'), array('.*?','$'), preg_quote($value_tmp, '#')) . '#', $path)) {
                 $flag = $value;
             }
         }

--- a/src/Diggin/RobotRules/Parser/TxtStringParser.php
+++ b/src/Diggin/RobotRules/Parser/TxtStringParser.php
@@ -49,7 +49,9 @@ class TxtStringParser
             $lineno++;
             
             if (!$line) {
-                $previous_line = false;
+                if ($line === false) {
+                    $previous_line = false;
+                }
                 continue;
             }
             
@@ -115,13 +117,13 @@ class TxtStringParser
      * parse a line
      *
      * @param string $line
-     * @return Line|array|false
+     * @return Line|array|null|false
      */ 
     public function parseLine($line)
     {        
         // start with comment?
         if (preg_match('!^\s*#!', $line)) {
-            return false;    
+            return null;    
         }
 
         preg_match('!\s*([^:]*):\s*([^#]*)\s*#*\s*([^\z]*)!i', 

--- a/tests/Diggin/RobotRules/Accepter/TxtGoogleWebmasterTest.php
+++ b/tests/Diggin/RobotRules/Accepter/TxtGoogleWebmasterTest.php
@@ -22,7 +22,7 @@ class TxtGoogleWebasterTest extends \PHPUnit_Framework_TestCase
 $txt = <<<EOF
 User-agent: Googlebot-Mobile
 Disallow: /path/
-# aa
+
 User-agent: Googlebot
 Disallow: /foo/bar/
 EOF;

--- a/tests/Diggin/RobotRules/Accepter/TxtTest.php
+++ b/tests/Diggin/RobotRules/Accepter/TxtTest.php
@@ -58,6 +58,19 @@ EOF;
 
         $accepter->setUserAgent('webcrawler');
         $this->assertTrue($accepter->isAllow('/bb/'));
+
+$txt = <<<EOF
+User-agent: webcrawler
+#comment
+User-agent: Googlebot
+#comment
+Disallow: /test
+EOF;
+        $accepter->setRules(TxtStringParser::parse($txt));
+
+        $accepter->setUserAgent('webcrawler');
+        $this->assertFalse($accepter->isAllow('/test/'));
+
     }
 
     public function testMultiUseragentSet()

--- a/tests/Diggin/RobotRules/Accepter/TxtTest.php
+++ b/tests/Diggin/RobotRules/Accepter/TxtTest.php
@@ -308,4 +308,40 @@ ROBOTSTXT;
         $this->assertTrue((boolean)$match, $record_path. ' '. $path);
     }
 
+    public function testSpecialChar()
+    {
+
+$txt = <<<EOF
+User-agent: *
+Disallow: /%23
+EOF;
+
+        $accepter = new TxtAccepter(); 
+        $accepter->setRules(TxtStringParser::parse($txt));
+
+        $accepter->setUserAgent('*');
+        $this->assertFalse($accepter->isAllow('/%23'));
+
+    }
+
+    public function testWildcardLong()
+    {
+
+$txt = <<<EOF
+User-agent: *
+Disallow: /****************************************.php
+Disallow: /*/*/*/*/*/*/*/*/*/*/*/*/*/*/*/*/*/*/*/*/test
+EOF;
+
+        $accepter = new TxtAccepter();
+        $accepter->setRules(TxtStringParser::parse($txt));
+
+        $accepter->setUserAgent('Googlebot');
+        $this->assertFalse($accepter->isAllow('/12345678901234567890.php'));
+        $this->assertTrue($accepter->isAllow('/12345678901234567890.ini'));
+        $this->assertFalse($accepter->isAllow('/1/2/3/4/5/6/7/8/9/0/1/2/3/4/5/6/7/8/9/0/test'));
+        $this->assertTrue($accepter->isAllow('/1/2/3/4/5/6/7/8/9/0/1/2/3/4/5/6/7/8/9/0/teest'));
+
+    }
+
 }

--- a/tests/Diggin/RobotRules/Accepter/TxtTest.php
+++ b/tests/Diggin/RobotRules/Accepter/TxtTest.php
@@ -88,6 +88,26 @@ EOF;
 
     }
 
+    public function testUserAgentCaseInsensitive()
+    {
+
+$txt = <<<EOF
+User-agent: Googlebot
+Disallow: /test/
+
+User-agent: *
+Disallow: /foo/bar/
+EOF;
+
+        $accepter = new TxtAccepter(); 
+        $accepter->setRules(TxtStringParser::parse($txt));
+
+        $accepter->setUserAgent('googleBot');
+        $this->assertFalse($accepter->isAllow('/test/1.jpg'));
+        $this->assertTrue($accepter->isAllow('/foo/bar/baz.html'));
+
+    }
+
     /**
      * @group robotsrfc
      * 


### PR DESCRIPTION
- User-agent names are case-insensitive:
  case insensitive match for names

- Comment cannot be used to separate records:
- Fix generated regex pattern:
  optimize regex for lessen backtrack and occational warning.